### PR TITLE
Yarel boolean tests extended

### DIFF
--- a/org.di.unito.yarel.parent/org.di.unito.yarel.tests/src/org/di/unito/yarel/tests/YarelGenerationTest.xtend
+++ b/org.di.unito.yarel.parent/org.di.unito.yarel.tests/src/org/di/unito/yarel/tests/YarelGenerationTest.xtend
@@ -1,4 +1,3 @@
-/*Added by Paolo Parker*/
 package org.di.unito.yarel.tests
 
 import javax.inject.Inject
@@ -10,22 +9,25 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 import static org.junit.Assert.*
+import java.util.ArrayList
 
 @RunWith(typeof(XtextRunner))
 @InjectWith(typeof(YarelInjectorProvider))
-class YarelGenerationTest 
-{
+class YarelGenerationTest{
+	
 	@Inject extension CompilationTestHelper
 	@Inject extension ReflectExtensions
 	
- 	@Test
-	def void testFunctionInc()
-	{
+	/**
+	 * Tests a simple inc function
+	 * Taken from Paolo Parker. Modified by Riccardo Viola.
+	 */
+	@Test
+	def void testFunctionInc(){
 		//Code in triple quotes gets compiled by calling compile() which in turn compiles with JavaYarelGenerator
 		//NOTE: if the code below has errors, the compilation doesn't even start
-		'''module mod
-		{
-			dcl f: int
+		'''module mod {
+			dcl f: int -> int
 			def f := inc
 		}'''.compile([
 			/* The goal here is to run the compiled class's b(ehaviour) method with java reflection
@@ -36,19 +38,21 @@ class YarelGenerationTest
 			val function = getCompiledClass("mod.f").getDeclaredConstructor.newInstance
 			
 			//parameters to be used when invoking the b(ehaviour) method
-			val int[] x = #[0]
+			val ArrayList<Object> x = new ArrayList<Object>()
+			x.add(0)
 			
 			/*Invokes the b(ehaviour) method in the generated function, with a simple parameter array x which
 			contains only the value 0. Since the operation is "inc", we expect this value to increase to 1.*/
-			var int[] actualx = function.invoke("b",x) as int[]
+			var ArrayList<Object> actualx = function.invoke("b",x) as ArrayList<Object>
 			
 			//actualx now contains the new parameter/s (changed after the invoke call) function in mod.f)
 			assertEquals(1,actualx.get(0))
 			
 			//Doing the same as above for the inverse function (mod.inv_f)
 			val inv_function = getCompiledClass("mod.inv_f").getDeclaredConstructor.newInstance
-			val int[] x_inv = #[0]
-			actualx = inv_function.invoke("b",x_inv) as int[]
+			val ArrayList<Object> x_inv = new ArrayList<Object>()
+			x_inv.add(0)
+			actualx = inv_function.invoke("b",x_inv) as ArrayList<Object>
 			assertEquals(-1,actualx.get(0))
 			
 			//Verifying that the arity of dcl f: int is actually 1 from the compiled java code
@@ -57,82 +61,121 @@ class YarelGenerationTest
 			])
 	}
 	
-	/*Each following test can be understood by reading the comments in the test above, because
-	they all have the same structure.*/
-	
-	//Tests a simple dec function
+	/**
+	 * Tests a simple id function with int
+	 * Taken from Paolo Parker. Modified by Riccardo Viola.
+	 */
 	@Test
-	def void testFunctionDec()
-	{
-		'''module mod
-		{
-			dcl f: int
-			def f := dec
-		}'''.compile([
-			//----------------REGULAR FUNCTION-----------------
-			val function = getCompiledClass("mod.f").getDeclaredConstructor.newInstance
-			val int[] x = #[0]
-			var int[] actualx = function.invoke("b",x) as int[]
-			assertEquals(-1,actualx.get(0))
-			
-			var actualArity = function.invoke("getA")
-			assertEquals(1,actualArity);
-			
-			//----------------INVERSE FUNCTION-----------------
-			val inv_function = getCompiledClass("mod.inv_f").getDeclaredConstructor.newInstance
-			val int[] x_inv = #[0]
-			actualx = inv_function.invoke("b",x_inv) as int[]
-			assertEquals(1,actualx.get(0))
-			
-			actualArity = inv_function.invoke("getA")
-			assertEquals(1,actualArity);
-			])
-	}
-	
-	//Tests a simple id function
-	@Test
-	def void testFunctionId()
-	{
-		'''module mod
-		{
-			dcl f: int
+	def void testFunctionId(){
+		'''module mod {
+			dcl f: int -> int
 			def f := id
 		}'''.compile([
 			//----------------REGULAR FUNCTION-----------------
 			val function = getCompiledClass("mod.f").getDeclaredConstructor.newInstance
-			val int[] x = #[0]
-			var int[] actualx = function.invoke("b",x) as int[]
-			assertEquals(0,actualx.get(0))
+			val ArrayList<Object> x = new ArrayList<Object>()
+			x.add(0)
+			var ArrayList<Object> actualx = function.invoke("b", x) as ArrayList<Object>
+			assertEquals(0, actualx.get(0))
 			
 			//testing arity
 			var actualArity = function.invoke("getA")
-			assertEquals(1,actualArity);
+			assertEquals(1, actualArity);
 			
 			//----------------INVERSE FUNCTION-----------------
 			val inv_function = getCompiledClass("mod.inv_f").getDeclaredConstructor.newInstance
-			val int[] x_inv = #[0]
-			actualx = inv_function.invoke("b",x_inv) as int[]
-			assertEquals(0,actualx.get(0))
+			val ArrayList<Object> x_inv = new ArrayList<Object>()
+			x_inv.add(0)
+			actualx = inv_function.invoke("b", x_inv) as ArrayList<Object>
+			assertEquals(0, actualx.get(0))
 			
 			//testing arity
 			actualArity = inv_function.invoke("getA")
-			assertEquals(1,actualArity);
+			assertEquals(1, actualArity);
 			])
 	}
 	
-	//Tests a simple neg function
+	/**
+	 * Tests a simple id function with bool
+	 * Added by Riccardo Viola.
+	 */
 	@Test
-	def void testFunctionNeg()
-	{
-		'''module mod
-		{
-			dcl f: int
+	def void testFunctionId2(){
+		'''module mod {
+			dcl f: bool -> bool
+			def f := id
+		}'''.compile([
+			//----------------REGULAR FUNCTION-----------------
+			val function = getCompiledClass("mod.f").getDeclaredConstructor.newInstance
+			val ArrayList<Object> x = new ArrayList<Object>()
+			x.add(true)
+			var ArrayList<Object> actualx = function.invoke("b", x) as ArrayList<Object>
+			assertEquals(true, actualx.get(0))
+			
+			//testing arity
+			var actualArity = function.invoke("getA")
+			assertEquals(1, actualArity);
+			
+			//----------------INVERSE FUNCTION-----------------
+			val inv_function = getCompiledClass("mod.inv_f").getDeclaredConstructor.newInstance
+			val ArrayList<Object> x_inv = new ArrayList<Object>()
+			x_inv.add(false)
+			actualx = inv_function.invoke("b", x_inv) as ArrayList<Object>
+			assertEquals(false, actualx.get(0))
+			
+			//testing arity
+			actualArity = inv_function.invoke("getA")
+			assertEquals(1, actualArity);
+			])
+	}
+	
+	/**
+	 * Tests a simple dec function
+	 * Taken from Paolo Parker. Modified by Riccardo Viola.
+	 */
+	@Test
+	def void testFunctionDec(){
+		'''module mod {
+			dcl f: int -> int
+			def f := dec
+		}'''.compile([
+			//----------------REGULAR FUNCTION-----------------
+			val function = getCompiledClass("mod.f").getDeclaredConstructor.newInstance
+			val ArrayList<Object> x = new ArrayList<Object>()
+			x.add(0)
+			var ArrayList<Object> actualx = function.invoke("b", x) as ArrayList<Object>
+			assertEquals(-1, actualx.get(0))
+			
+			var actualArity = function.invoke("getA")
+			assertEquals(1, actualArity);
+			
+			//----------------INVERSE FUNCTION-----------------
+			val inv_function = getCompiledClass("mod.inv_f").getDeclaredConstructor.newInstance
+			val ArrayList<Object> x_inv = new ArrayList<Object>()
+			x_inv.add(0)
+			actualx = inv_function.invoke("b", x_inv) as ArrayList<Object>
+			assertEquals(1, actualx.get(0))
+			
+			actualArity = inv_function.invoke("getA")
+			assertEquals(1, actualArity);
+			])
+	}
+	
+	/**
+	 * Tests a simple neg function
+	 * Taken from Paolo Parker. Modified by Riccardo Viola.
+	 */
+	@Test
+	def void testFunctionNeg(){
+		'''module mod {
+			dcl f: int -> int
 			def f := neg
 		}'''.compile([
 			//----------------REGULAR FUNCTION-----------------
 			val function = getCompiledClass("mod.f").getDeclaredConstructor.newInstance
-			val int[] x = #[5]
-			var int[] actualx = function.invoke("b",x) as int[]
+			val ArrayList<Object> x = new ArrayList<Object>()
+			x.add(5)
+			var ArrayList<Object> actualx = function.invoke("b",x) as ArrayList<Object>
 			assertEquals(-5,actualx.get(0))
 			
 			//testing arity
@@ -141,8 +184,9 @@ class YarelGenerationTest
 			
 			//----------------INVERSE FUNCTION-----------------
 			val inv_function = getCompiledClass("mod.inv_f").getDeclaredConstructor.newInstance
-			val int[] x_inv = #[5]
-			actualx = inv_function.invoke("b",x_inv) as int[]
+			val ArrayList<Object> x_inv = new ArrayList<Object>()
+			x_inv.add(5)
+			actualx = inv_function.invoke("b",x_inv) as ArrayList<Object>
 			assertEquals(-5,actualx.get(0))
 			
 			//testing arity
@@ -151,20 +195,22 @@ class YarelGenerationTest
 			])
 	}
 	
-	//Tests a function with 3 serially executed primitive functions (inc and dec)
+	/**
+	 * Tests a function with 3 serially executed primitive functions (inc and dec)
+	 * Taken from Paolo Parker. Modified by Riccardo Viola.
+	 */
 	@Test
-	def void testFunctionSerComp()
-	{
-		'''module mod
-		{
-			dcl f: int
+	def void testFunctionSerComp(){
+		'''module mod {
+			dcl f: int -> int
 			def f := inc;dec;inc
 		}'''.compile([
 			//----------------REGULAR FUNCTION-----------------
 			val function = getCompiledClass("mod.f").getDeclaredConstructor.newInstance
-			println(getGeneratedCode("mod.f"))
-			val int[] x = #[10]
-			var int[] actualx = function.invoke("b",x) as int[]
+
+			val ArrayList<Object> x = new ArrayList<Object>()
+			x.add(10)
+			var ArrayList<Object> actualx = function.invoke("b",x) as ArrayList<Object>
 			assertEquals(11,actualx.get(0))
 			
 			//testing arity
@@ -173,8 +219,9 @@ class YarelGenerationTest
 			
 			//----------------INVERSE FUNCTION-----------------
 			val inv_function = getCompiledClass("mod.inv_f").getDeclaredConstructor.newInstance
-			val int[] x_inv = #[4]
-			actualx = inv_function.invoke("b",x_inv) as int[]
+			val ArrayList<Object> x_inv = new ArrayList<Object>()
+			x_inv.add(4)
+			actualx = inv_function.invoke("b",x_inv) as ArrayList<Object>
 			assertEquals(3,actualx.get(0))
 			
 			//testing arity
@@ -183,22 +230,27 @@ class YarelGenerationTest
 			])
 	}
 	
-	//Tests a function with 3 parallel-executed primitive functions (inc and dec)
+	/**
+	 * Tests a function with 3 parallel-executed primitive functions (inc and dec)
+	 * Taken from Paolo Parker. Modified by Riccardo Viola.
+	 */
 	@Test
-	def void testFunctionParComp()
-	{
-		'''module mod
-		{
-			dcl f: int,int,int
+	def void testFunctionParComp(){
+		'''module mod {
+			dcl f: int,int,int -> int,int,int
 			def f := inc|dec|inc
 		}'''.compile([
 			//----------------REGULAR FUNCTION-----------------
 			val function = getCompiledClass("mod.f").getDeclaredConstructor.newInstance
-			println(getGeneratedCode("mod.f"))
-			val int[] x = #[10,15,20]
-			var int[] actualx = function.invoke("b",x) as int[]
-			var int[] expectedx = #[11,14,21]
-			assertArrayEquals(expectedx,actualx)
+
+			val ArrayList<Object> x = new ArrayList<Object>()
+			x.add(10)
+			x.add(15)
+			x.add(20)
+			var ArrayList<Object> actualx = function.invoke("b",x) as ArrayList<Object>
+			assertEquals(11,actualx.get(0))
+			assertEquals(14,actualx.get(1))
+			assertEquals(21,actualx.get(2))
 			
 			//testing arity
 			var actualArity = function.invoke("getA")
@@ -206,32 +258,43 @@ class YarelGenerationTest
 			
 			//----------------INVERSE FUNCTION-----------------
 			val inv_function = getCompiledClass("mod.inv_f").getDeclaredConstructor.newInstance
-			val int[] x_inv = #[4,5,6]
-			actualx = inv_function.invoke("b",x_inv) as int[]
-			expectedx = #[3,6,5]
-			assertArrayEquals(expectedx,actualx)
+			val ArrayList<Object> x_inv = new ArrayList<Object>()
+			x_inv.add(4)
+			x_inv.add(5)
+			x_inv.add(6)
+			actualx = inv_function.invoke("b",x_inv) as ArrayList<Object>
+			assertEquals(3,actualx.get(0))
+			assertEquals(6,actualx.get(1))
+			assertEquals(5,actualx.get(2))
 			
 			actualArity = inv_function.invoke("getA")
 			assertEquals(3,actualArity);
 			])
 	}
 	
-	//Tests a function with a simple permutation with 4 indices
+	/**
+	 * Tests a function with a simple permutation with 4 indices
+	 * Taken from Paolo Parker. Modified by Riccardo Viola.
+	 */
 	@Test
-	def void testFunctionPerm()
-	{
-		'''module mod
-		{
-			dcl f: int,int,int,int
+	def void testFunctionPerm(){
+		'''module mod {
+			dcl f: int,int,int,int -> int,int,int,int
 			def f := /2 4 3 1/
 		}'''.compile([
 			//----------------REGULAR FUNCTION-----------------
 			val function = getCompiledClass("mod.f").getDeclaredConstructor.newInstance
-			println(getGeneratedCode("mod.f"))
-			val int[] x = #[1,2,3,4]
-			var int[] actualx = function.invoke("b",x) as int[]
-			var int[] expectedx = #[2,4,3,1]
-			assertArrayEquals(expectedx,actualx)
+
+			val ArrayList<Object> x = new ArrayList<Object>()
+			x.add(1)
+			x.add(2)
+			x.add(3)
+			x.add(4)
+			var ArrayList<Object> actualx = function.invoke("b",x) as ArrayList<Object>
+			assertEquals(2,actualx.get(0))
+			assertEquals(4,actualx.get(1))
+			assertEquals(3,actualx.get(2))
+			assertEquals(1,actualx.get(3))
 			
 			//testing arity
 			var actualArity = function.invoke("getA")
@@ -239,10 +302,16 @@ class YarelGenerationTest
 			
 			//----------------INVERSE FUNCTION-----------------
 			val inv_function = getCompiledClass("mod.inv_f").getDeclaredConstructor.newInstance
-			val int[] x_inv = #[1,2,3,4]
-			actualx = inv_function.invoke("b",x_inv) as int[]
-			expectedx = #[4,1,3,2]
-			assertArrayEquals(expectedx,actualx)
+			val ArrayList<Object> x_inv = new ArrayList<Object>()
+			x_inv.add(1)
+			x_inv.add(2)
+			x_inv.add(3)
+			x_inv.add(4)
+			actualx = inv_function.invoke("b",x_inv) as ArrayList<Object>
+			assertEquals(4,actualx.get(0))
+			assertEquals(1,actualx.get(1))
+			assertEquals(3,actualx.get(2))
+			assertEquals(2,actualx.get(3))
 			
 			//testing arity
 			actualArity = inv_function.invoke("getA")
@@ -250,144 +319,96 @@ class YarelGenerationTest
 			])
 	}
 	
-	//Various tests for the iteration (it)
+	/**
+	 * Tests a function with a simple iteration loop
+	 * Taken from Paolo Parker. Modified by Riccardo Viola.
+	 */
 	@Test
-	def void testFunctionIt()
-	{
-		//Testing the iteration based on its definition v = 0 (ITZ)
-		'''module mod
-		{
-			dcl premise: int,int /* Premise of the rule ITZ */
-		        def premise := (id|id)
-		
-			dcl conclusion: int,int /* Conlcusion of the rule ITZ */
-		        def conclusion := it[inc]
+	def void testFunctionIt(){
+		'''module mod {
+			dcl f: int,int -> int,int
+			def f := it[inc]
 		}'''.compile([
 			//----------------REGULAR FUNCTION-----------------
-			val premise = getCompiledClass("mod.premise").getDeclaredConstructor.newInstance
-		 	val conclusion = getCompiledClass("mod.conclusion").getDeclaredConstructor.newInstance
+			val function = getCompiledClass("mod.f").getDeclaredConstructor.newInstance
 			
-		 	val int[] input = #[5,0]
-			var int[] outputOfPremise = premise.invoke("b",input) as int[]
-			var int[] outputOfConclusion = conclusion.invoke("b",input) as int[]
-			assertArrayEquals(premise.invoke("b",input) as int[],outputOfConclusion)
-		])
-		
-		//Testing the iteration based on its definition for positive v (ITG)
-		'''module mod
-		{
-			dcl premise: int,int /* Premise of the rule ITG */
-		        def premise := (inc|dec);it[inc];(id|inc)
-		
-			dcl conclusion: int,int /* Conlcusion of the rule ITG */
-		        def conclusion := it[inc]
-		}'''.compile([
-			//----------------REGULAR FUNCTION-----------------
-			val premise = getCompiledClass("mod.premise").getDeclaredConstructor.newInstance
-		 	val conclusion = getCompiledClass("mod.conclusion").getDeclaredConstructor.newInstance
+			//testing for positive v
+			val ArrayList<Object> x_pos = new ArrayList<Object>()
+			x_pos.add(5)
+			x_pos.add(10)
+			var ArrayList<Object> actualx = function.invoke("b",x_pos) as ArrayList<Object>
+			assertEquals(15,actualx.get(0))
+			assertEquals(10,actualx.get(1))
 			
-		 	val int[] input = #[5,10]
-			var int[] outputOfPremise = premise.invoke("b",input) as int[]
-			var int[] outputOfConclusion = conclusion.invoke("b",input) as int[]
-			assertArrayEquals(outputOfPremise,outputOfConclusion)
-		])
-		
-		//Testing the iteration based on its definition for negative v (ITS)
-		'''module mod
-		{
-			dcl premise: int,int /* Premise of the rule ITS */
-		        def premise := (inc|inc);it[inc];(id|dec)
-		
-			dcl conclusion: int,int /* Conlcusion of the rule ITS */
-		        def conclusion := it[inc]
-		}'''.compile([
-			//----------------REGULAR FUNCTION-----------------
-			val premise = getCompiledClass("mod.premise").getDeclaredConstructor.newInstance
-		 	val conclusion = getCompiledClass("mod.conclusion").getDeclaredConstructor.newInstance
+			//testing for v = 0
+			val ArrayList<Object> x_zero = new ArrayList<Object>()
+			x_zero.add(5)
+			x_zero.add(0)
+			actualx = function.invoke("b",x_zero) as ArrayList<Object>
+			assertEquals(5,actualx.get(0))
+			assertEquals(0,actualx.get(1))
 			
-		 	val int[] input = #[5,-10]
-			var int[] outputOfPremise = premise.invoke("b",input) as int[]
-			var int[] outputOfConclusion = conclusion.invoke("b",input) as int[]
-			assertArrayEquals(outputOfPremise,outputOfConclusion)
-		])
+			//testing for negative v
+			val ArrayList<Object> x_neg = new ArrayList<Object>()
+			x_neg.add(5)
+			x_neg.add(-8)
+			actualx = function.invoke("b",x_neg) as ArrayList<Object>
+			assertEquals(13,actualx.get(0))
+			assertEquals(-8,actualx.get(1))
+			
+			//Testing arity
+			var actualArity = function.invoke("getA")
+			assertEquals(2,actualArity);
+			
+			//----------------INVERSE FUNCTION-----------------
+			val inv_function = getCompiledClass("mod.inv_f").getDeclaredConstructor.newInstance
+			
+			//testing for positive v
+			val ArrayList<Object> x_invPos = new ArrayList<Object>()
+			x_invPos.add(5)
+			x_invPos.add(10)
+			actualx = inv_function.invoke("b",x_invPos) as ArrayList<Object>
+			assertEquals(-5,actualx.get(0))
+			assertEquals(10,actualx.get(1))
+			
+			//testing for v = 0
+			val ArrayList<Object> x_invZero = new ArrayList<Object>()
+			x_invZero.add(5)
+			x_invZero.add(0)
+			actualx = inv_function.invoke("b",x_invZero) as ArrayList<Object>
+			assertEquals(5,actualx.get(0))
+			assertEquals(0,actualx.get(1))
+			
+			//testing for negative v
+			val ArrayList<Object> x_invNeg = new ArrayList<Object>()
+			x_invNeg.add(5)
+			x_invNeg.add(-3)
+			actualx = inv_function.invoke("b",x_invNeg) as ArrayList<Object>
+			assertEquals(2,actualx.get(0))
+			assertEquals(-3,actualx.get(1))
+			
+			//Testing arity
+			actualArity = inv_function.invoke("getA")
+			assertEquals(2,actualArity);
+			])
 	}
 	
+	/**
+	 * Tests a function with a simple inverse function
+	 * Taken from Paolo Parker. Modified by Riccardo Viola.
+	 */
 	@Test
-	def void testFunctionFor()
-	{
-		
-		//Testing the for loop based on its definition v = 0
-		'''module mod
-		{
-			dcl premise: int,int
-		        def premise := (id|id)
-		
-			dcl conclusion: int,int
-		        def conclusion := for[inc]
-		}'''.compile([
-			//----------------REGULAR FUNCTION-----------------
-			val premise = getCompiledClass("mod.premise").getDeclaredConstructor.newInstance
-		 	val conclusion = getCompiledClass("mod.conclusion").getDeclaredConstructor.newInstance
-			
-		 	val int[] input = #[5,0]
-			var int[] outputOfPremise = premise.invoke("b",input) as int[]
-			var int[] outputOfConclusion = conclusion.invoke("b",input) as int[]
-			assertArrayEquals(outputOfPremise,outputOfConclusion)
-		])
-		
-		//Testing the for loop based on its definition for positive v
-		'''module mod
-		{
-			dcl premise: int,int
-		        def premise := (inc|dec);for[inc];(id|inc)
-		
-			dcl conclusion: int,int
-		        def conclusion := for[inc]
-		}'''.compile([
-			//----------------REGULAR FUNCTION-----------------
-			val premise = getCompiledClass("mod.premise").getDeclaredConstructor.newInstance
-		 	val conclusion = getCompiledClass("mod.conclusion").getDeclaredConstructor.newInstance
-			
-		 	val int[] input = #[5,10]
-			var int[] outputOfPremise = premise.invoke("b",input) as int[]
-			var int[] outputOfConclusion = conclusion.invoke("b",input) as int[]
-			assertArrayEquals(outputOfPremise,outputOfConclusion)
-		])
-		
-		//Testing the for loop based on its definition for negative v
-		'''module mod
-		{
-			dcl premise: int,int
-		        def premise := (inv[inc]|inc);for[inc];(id|dec)
-		
-			dcl conclusion: int,int
-		        def conclusion := for[inc]
-		}'''.compile([
-			//----------------REGULAR FUNCTION-----------------
-			val premise = getCompiledClass("mod.premise").getDeclaredConstructor.newInstance
-		 	val conclusion = getCompiledClass("mod.conclusion").getDeclaredConstructor.newInstance
-			
-		 	val int[] input = #[5,-10]
-			var int[] outputOfPremise = premise.invoke("b",input) as int[]
-			var int[] outputOfConclusion = conclusion.invoke("b",input) as int[]
-			assertArrayEquals(outputOfPremise,outputOfConclusion)
-		])
-	}
-	
-	//Tests a function with a simple inverse function
-	@Test
-	def void testFunctionInv()
-	{
-		'''module mod
-		{
-			dcl f: int
+	def void testFunctionInv(){
+		'''module mod {
+			dcl f: int -> int
 			def f := inv[inc]
 		}'''.compile([
 			//----------------REGULAR FUNCTION-----------------
 			val function = getCompiledClass("mod.f").getDeclaredConstructor.newInstance
-			println(getGeneratedCode("mod.f"))
-			val int[] x = #[5]
-			var int[] actualx = function.invoke("b",x) as int[]
+
+			val ArrayList<Object> x = new ArrayList<Object>()
+			x.add(5)
+			var ArrayList<Object> actualx = function.invoke("b",x) as ArrayList<Object>
 			assertEquals(4,actualx.get(0))
 			
 			//Testing arity
@@ -396,8 +417,9 @@ class YarelGenerationTest
 			
 			//----------------INVERSE FUNCTION-----------------
 			val inv_function = getCompiledClass("mod.inv_f").getDeclaredConstructor.newInstance
-			val int[] x_inv = #[5]
-			actualx = inv_function.invoke("b",x_inv) as int[]
+			val ArrayList<Object> x_inv = new ArrayList<Object>()
+			x_inv.add(5)
+			actualx = inv_function.invoke("b",x_inv) as ArrayList<Object>
 			assertEquals(6,actualx.get(0))
 			
 			//Testing arity
@@ -406,37 +428,43 @@ class YarelGenerationTest
 			])
 	}
 	
-	//Tests a function with a simple if statement
+	/**
+	 * Tests a function with a simple if statement
+	 * Taken from Paolo Parker. Modified by Riccardo Viola.
+	 */
 	@Test
-	def void testFunctionIf()
-	{
-		'''module mod
-		{
-			dcl f: int,int
+	def void testFunctionIf(){
+		'''module mod {
+			dcl f: int,int -> int,int
 			def f := if[inc,id,dec]
 		}'''.compile([
 			
 			//----------------REGULAR FUNCTION-----------------
 			val function = getCompiledClass("mod.f").getDeclaredConstructor.newInstance
-			println(getGeneratedCode("mod.f"))
 			
 			//testing for positive v
-			val int[] x_pos = #[5,13]
-			var int[] actualx = function.invoke("b",x_pos) as int[]
-			var int[] expectedx = #[6,13]
-			assertArrayEquals(expectedx,actualx)
+			val ArrayList<Object> x_pos = new ArrayList<Object>()
+			x_pos.add(5)
+			x_pos.add(13)
+			var ArrayList<Object> actualx = function.invoke("b",x_pos) as ArrayList<Object>
+			assertEquals(6,actualx.get(0))
+			assertEquals(13,actualx.get(1))
 			
 			//testing for v = 0
-			val int[] x_zero = #[5,0]
-			actualx = function.invoke("b",x_zero) as int[]
-			expectedx = #[5,0]
-			assertArrayEquals(expectedx,actualx)
+			val ArrayList<Object> x_zero = new ArrayList<Object>()
+			x_zero.add(5)
+			x_zero.add(0)
+			actualx = function.invoke("b",x_zero) as ArrayList<Object>
+			assertEquals(5,actualx.get(0))
+			assertEquals(0,actualx.get(1))
 			
 			//testing for negative v
-			val int[] x_neg = #[5,-8]
-			actualx = function.invoke("b",x_neg) as int[]
-			expectedx = #[4,-8]
-			assertArrayEquals(expectedx,actualx)
+			val ArrayList<Object> x_neg = new ArrayList<Object>()
+			x_neg.add(5)
+			x_neg.add(-8)
+			actualx = function.invoke("b",x_neg) as ArrayList<Object>
+			assertEquals(4,actualx.get(0))
+			assertEquals(-8,actualx.get(1))
 			
 			//Testing arity
 			var actualArity = function.invoke("getA")
@@ -446,26 +474,109 @@ class YarelGenerationTest
 			val inv_function = getCompiledClass("mod.inv_f").getDeclaredConstructor.newInstance
 			
 			//testing for positive v
-			val int[] x_invPos = #[5,13]
-			actualx = inv_function.invoke("b",x_invPos) as int[]
-			expectedx = #[4,13]
-			assertArrayEquals(expectedx,actualx)
+			val ArrayList<Object> x_invPos = new ArrayList<Object>()
+			x_invPos.add(5)
+			x_invPos.add(13)
+			actualx = inv_function.invoke("b",x_invPos) as ArrayList<Object>
+			assertEquals(4,actualx.get(0))
+			assertEquals(13,actualx.get(1))
 			
 			//testing for v = 0
-			val int[] x_invZero = #[5,0]
-			actualx = inv_function.invoke("b",x_invZero) as int[]
-			expectedx = #[5,0]
-			assertArrayEquals(expectedx,actualx)
+			val ArrayList<Object> x_invZero = new ArrayList<Object>()
+			x_invZero.add(5)
+			x_invZero.add(0)
+			actualx = inv_function.invoke("b",x_invZero) as ArrayList<Object>
+			assertEquals(5,actualx.get(0))
+			assertEquals(0,actualx.get(1))
 			
 			//testing for negative v
-			val int[] x_invNeg = #[5,-3]
-			actualx = inv_function.invoke("b",x_invNeg) as int[]
-			expectedx = #[6,-3]
-			assertArrayEquals(expectedx,actualx)
+			val ArrayList<Object> x_invNeg = new ArrayList<Object>()
+			x_invNeg.add(5)
+			x_invNeg.add(-3)
+			actualx = inv_function.invoke("b",x_invNeg) as ArrayList<Object>
+			assertEquals(6,actualx.get(0))
+			assertEquals(-3,actualx.get(1))
 			
 			//Testing arity
 			actualArity = inv_function.invoke("getA")
 			assertEquals(2,actualArity);
 			])
 	}
+	
+	/**
+	 * Tests a simple not function
+	 * Added by Riccardo Viola.
+	 */
+	@Test
+	def void testFunctionNot(){
+		'''module mod {
+			dcl f: bool -> bool
+			def f := not
+		}'''.compile([
+			//----------------REGULAR FUNCTION-----------------
+			val function = getCompiledClass("mod.f").getDeclaredConstructor.newInstance			
+			val ArrayList<Object> x = new ArrayList<Object>()
+			x.add(false)
+			var ArrayList<Object> actualx = function.invoke("b", x) as ArrayList<Object>
+			assertEquals(true, actualx.get(0))
+			
+			//testing arity
+			var actualArity = function.invoke("getA")
+			assertEquals(1, actualArity);
+			
+			//----------------INVERSE FUNCTION-----------------
+			val inv_function = getCompiledClass("mod.inv_f").getDeclaredConstructor.newInstance
+			val ArrayList<Object> x_inv = new ArrayList<Object>()
+			x_inv.add(true)
+			actualx = inv_function.invoke("b", x_inv) as ArrayList<Object>
+			assertEquals(false, actualx.get(0))
+			
+			//testing arity
+			actualArity = inv_function.invoke("getA")
+			assertEquals(1, actualArity);
+			])
+	}
+	
+	/**
+	 * Tests a simple tof function
+	 * Added by Riccardo Viola.
+	 */
+	@Test
+	def void testFunctionTof(){
+		'''module mod {
+			dcl f: 3 bool -> 3 bool
+			def f := tof
+		}'''.compile([
+			//----------------REGULAR FUNCTION-----------------
+			val function = getCompiledClass("mod.f").getDeclaredConstructor.newInstance
+			val ArrayList<Object> x = new ArrayList<Object>()
+			x.add(true)
+			x.add(true)
+			x.add(false)
+			var ArrayList<Object> actualx = function.invoke("b", x) as ArrayList<Object>
+			assertEquals(true, actualx.get(0))
+			assertEquals(true, actualx.get(1))
+			assertEquals(true, actualx.get(2))
+			
+			//testing arity
+			var actualArity = function.invoke("getA")
+			assertEquals(3, actualArity);
+			
+			//----------------INVERSE FUNCTION-----------------
+			val inv_function = getCompiledClass("mod.inv_f").getDeclaredConstructor.newInstance
+			val ArrayList<Object> x_inv = new ArrayList<Object>()
+			x_inv.add(true)
+			x_inv.add(true)
+			x_inv.add(true)
+			actualx = inv_function.invoke("b", x_inv) as ArrayList<Object>
+			assertEquals(true, actualx.get(0))
+			assertEquals(true, actualx.get(1))
+			assertEquals(false, actualx.get(2))
+			
+			//testing arity
+			actualArity = inv_function.invoke("getA")
+			assertEquals(3, actualArity);
+			])
+	}
+	
 }

--- a/org.di.unito.yarel.parent/org.di.unito.yarel.tests/src/org/di/unito/yarel/tests/YarelValidationTest.xtend
+++ b/org.di.unito.yarel.parent/org.di.unito.yarel.tests/src/org/di/unito/yarel/tests/YarelValidationTest.xtend
@@ -1,429 +1,309 @@
-/*Added by Paolo Parker*/
 package org.di.unito.yarel.tests
 
-import static extension org.eclipse.xtext.EcoreUtil2.*
-
-import static extension org.junit.Assert.*
-import org.junit.runner.RunWith
 import javax.inject.Inject
-import org.junit.Test
+import org.di.unito.yarel.validation.YarelValidator
 import org.di.unito.yarel.yarel.Model
-import org.di.unito.yarel.yarel.Definition
-import org.di.unito.yarel.yarel.Declaration
-import org.di.unito.yarel.yarel.Body
-import org.di.unito.yarel.yarel.SerComp
-import org.di.unito.yarel.yarel.ParComp
-import org.di.unito.yarel.yarel.BodyInc
-import org.di.unito.yarel.yarel.BodyDec
-import org.di.unito.yarel.yarel.BodyFun
-import org.di.unito.yarel.yarel.BodyPerm
-import org.di.unito.yarel.yarel.Type
-import org.di.unito.yarel.yarel.Signature
-import java.util.ArrayList
-import org.di.unito.yarel.yarel.Permutation
-import org.eclipse.xtext.testing.XtextRunner
+import org.di.unito.yarel.yarel.YarelPackage
 import org.eclipse.xtext.testing.InjectWith
+import org.eclipse.xtext.testing.XtextRunner
 import org.eclipse.xtext.testing.util.ParseHelper
 import org.eclipse.xtext.testing.validation.ValidationTestHelper
-import org.di.unito.yarel.yarel.BodyFor
-import org.di.unito.yarel.yarel.BodyIt
-import org.di.unito.yarel.yarel.BodyInv
-import org.di.unito.yarel.yarel.BodyIf
-import org.di.unito.yarel.yarel.BodyId
-import org.di.unito.yarel.yarel.YarelPackage
-import org.di.unito.yarel.validation.YarelValidator
-import org.eclipse.emf.ecore.EObject
+import org.junit.Test
+import org.junit.runner.RunWith
 
 @RunWith(typeof(XtextRunner))
 @InjectWith(typeof(YarelInjectorProvider))
 
-class YarelValidationTest 
-{
+class YarelValidationTest{
+	
 	@Inject extension ParseHelper<Model>
  	@Inject extension ValidationTestHelper //utilities for testing validation
 	
+	/**
+	 * Added by Riccardo Viola.
+	 */
 	@Test
-	def void testWrongArity()
-	{
-		var model = '''module m 
-					   {
-					   		dcl f: int, int
-							def f := inc
-					   }'''.parse
-		model.assertError(YarelPackage::eINSTANCE.getDefinition(),YarelValidator::ERROR_ARITY,"Different arities")
-	}
-	
-	@Test
-	def void testWrongIfArities()
-	{
-		var model = '''module m 
-					   {
-					   		dcl positive: int
-					   		dcl zero: int
-					   		dcl negative: int, int
-					   		dcl f: int, int
-					   		
-					   		def positive := inc
-					   		def zero := dec
-					   		def negative := inc|dec
-					   		
-							def f := if[positive,zero,negative]
-					   }'''.parse
-		model.assertError(YarelPackage::eINSTANCE.getBodyIf(),YarelValidator::ERROR_IF_FUNCTIONS_ARITY,"Arity of positive, zero and negative functions must be equal")
-	}
-	
-	@Test
-	def void testWrongSerCompArities()
-	{
-		var model = '''module m 
-					   {
-					   		dcl left: int
-					   		dcl right: int, int
-					   		dcl f: int
-					   		
-							def f := left;right
-					   }'''.parse
-		model.assertError(YarelPackage::eINSTANCE.getSerComp(),YarelValidator::ERROR_SERIAL_COMPOSITION,"Arity of left and right branch must be equal")
-	}
-	
-	//Testing if one or more indices of the permutation definition is out of bounds
-	@Test
-	def void testWrongPermutationIndex0()
-	{
-		var model = '''module m 
-					   {
-					   		dcl f: int, int, int, int
-					   		
-							def f := /3 2 4 5/
-					   }'''.parse
-		var arity = ((model.elements.get(0) as Declaration).signature as Signature).types.size()
-		model.assertError(YarelPackage::eINSTANCE.getBodyPerm(),YarelValidator::ERROR_PERMUTATION_BOUND,"Index of permutation out of bound, it must be between 1 and "+arity)
-	}
-	
-	//Testing if two or more indices have the same value in the permutation definition
-	@Test
-	def void testWrongPermutationIndex1()
-	{
-		var model = '''module m 
-					   {
-					   		dcl f: int, int, int, int
-					   		
-							def f := /3 2 4 4/
-					   }'''.parse
-		model.assertError(YarelPackage::eINSTANCE.getBodyPerm(),YarelValidator::ERROR_PERMUTATION_INDICES,"Indices must be all different")
-	}
-	//----------------------------------------NEW STUFF----------------------------------------------------
-	//Testing if one or more indices of the permutation definition is out of bounds
-	@Test
-	def void testWrongPermutationIndex2()
-	{
-		var model = '''module m 
-		{ 
-			dcl f: int, int, int, int 
-			def f := /3 1 4/
+	def void testMultipleDeclarations1(){
+		var model = '''module m {
+			dcl f: 2 int -> 2 int
+		    dcl f: 2 bool -> 2 bool
 		}'''.parse
-		model.assertError(YarelPackage::eINSTANCE.getDefinition(),YarelValidator::ERROR_ARITY,"Different arities")
+		model.assertError(YarelPackage::eINSTANCE.getDeclaration(), YarelValidator::ERROR_DECLARATION_NAME, "Declarations must have different names")
 	}
 	
-	//Testing if one or more indices of the permutation definition is out of bounds
+	/**
+	 * Added by Riccardo Viola.
+	 */
 	@Test
-	def void testWrongPermutationIndex3()
-	{
-		var model = '''module m 
-		{ 
-			dcl f: int, int, int, int 
-			def f := /1 3/
+	def void testMultipleDeclarations2(){
+		var model = '''module m {
+			dcl f: 2 int -> 2 int
+			dcl f: 2 int -> 2 int
 		}'''.parse
-		model.assertError(YarelPackage::eINSTANCE.getDefinition(),YarelValidator::ERROR_ARITY,"Different arities")
+		model.assertError(YarelPackage::eINSTANCE.getDeclaration(), YarelValidator::ERROR_DECLARATION_NAME, "Declarations must have different names")
 	}
 	
-	//For loop
-	
+	/**
+	 * Added by Riccardo Viola.
+	 */
 	@Test
-	def void testWrongDefinitionArity0()
-	{
-		var model = '''module m 
-		{ 
-			dcl f: int
-		    def f := for[f];f 
+	def void testTypesLAndR1(){
+		var model = '''module m {
+			dcl f: 2 int, bool -> int, 2 bool
 		}'''.parse
-		model.assertError(YarelPackage::eINSTANCE.getDefinition(),YarelValidator::ERROR_ARITY,"Different arities")
+		model.assertError(YarelPackage::eINSTANCE.getDeclaration(), YarelValidator::ERROR_SIGNATURES_TYPE, "Types of signaturesL and signaturesR must be equal")
 	}
 	
+	/**
+	 * Added by Riccardo Viola.
+	 */
 	@Test
-	def void testWrongDefinitionArity1()
-	{
-		var model = '''module m 
-		{ 
-			dcl f: int
-		    def f := f;for[f] 
+	def void testTypesLAndR2(){
+		var model = '''module m {
+			dcl f: int, bool -> bool, bool
 		}'''.parse
-		model.assertError(YarelPackage::eINSTANCE.getSerComp(),YarelValidator::ERROR_SERIAL_COMPOSITION,"Arity of left and right branch must be equal")
+		model.assertError(YarelPackage::eINSTANCE.getDeclaration(), YarelValidator::ERROR_SIGNATURES_TYPE, "Types of signaturesL and signaturesR must be equal")
 	}
 	
+	/**
+	 * Added by Riccardo Viola.
+	 */
 	@Test
-	def void testWrongDefinitionArity2()
-	{
-		var model = '''module m 
-		{ 
-			dcl f: 2 int
-		    def f := f;for[f] 
+	def void testTypesLAndR3(){
+		var model = '''module m {
+			dcl f: 2 int, 3 bool -> bool, bool, int, int, int
 		}'''.parse
-		model.assertError(YarelPackage::eINSTANCE.getSerComp(),YarelValidator::ERROR_SERIAL_COMPOSITION,"Arity of left and right branch must be equal")
+		model.assertError(YarelPackage::eINSTANCE.getDeclaration(), YarelValidator::ERROR_SIGNATURES_TYPE, "Types of signaturesL and signaturesR must be equal")
 	}
 	
+	/**
+	 * Added by Riccardo Viola.
+	 */
 	@Test
-	def void testWrongDefinitionArity3()
-	{
-		var model = '''module m 
-		{ 
-			dcl f: int, int
-		    def f := f;for[f] 
+	def void testOperationsLinking1(){
+		var model = '''module m {
+			dcl f : bool -> bool
+			def f := dec
 		}'''.parse
-		model.assertError(YarelPackage::eINSTANCE.getSerComp(),YarelValidator::ERROR_SERIAL_COMPOSITION,"Arity of left and right branch must be equal")
+		model.assertError(YarelPackage::eINSTANCE.getDefinition(), YarelValidator::ERROR_OPERATIONS_TYPE, "Operations and input types are bad linked")
 	}
 	
+	/**
+	 * Added by Riccardo Viola.
+	 */
 	@Test
-	def void testWrongDefinitionArity4()
-	{
-		var model = '''module m 
-		{ 
-			dcl f: int
-		    def f := /1/;for[inc] 
+	def void testOperationsLinking2(){
+		var model = '''module m {
+			dcl f : bool -> bool
+			def f := inc
 		}'''.parse
-		model.assertError(YarelPackage::eINSTANCE.getSerComp(),YarelValidator::ERROR_SERIAL_COMPOSITION,"Arity of left and right branch must be equal")
+		model.assertError(YarelPackage::eINSTANCE.getDefinition(), YarelValidator::ERROR_OPERATIONS_TYPE, "Operations and input types are bad linked")
 	}
 	
+	/**
+	 * Added by Riccardo Viola.
+	 */
 	@Test
-	def void testWrongDefinitionArity5()
-	{
-		var model = '''module m 
-		{ 
-			dcl f: int
-		    def f := for[inc];/1/ 
+	def void testOperationsLinking3(){
+		var model = '''module m {
+			dcl f : bool -> bool
+			def f := neg
 		}'''.parse
-		model.assertError(YarelPackage::eINSTANCE.getSerComp(),YarelValidator::ERROR_SERIAL_COMPOSITION,"Arity of left and right branch must be equal")
+		model.assertError(YarelPackage::eINSTANCE.getDefinition(), YarelValidator::ERROR_OPERATIONS_TYPE, "Operations and input types are bad linked")
 	}
 	
+	/**
+	 * Added by Riccardo Viola.
+	 */
 	@Test
-	def void testWrongDefinitionArity6()
-	{
-		var model = '''module m 
-		{ 
-			dcl f: int
-		    def f := /1 2 3/;for[inc] 
+	def void testOperationsLinking4(){
+		var model = '''module m {
+			dcl f : int -> int
+			def f := not
 		}'''.parse
-		model.assertError(YarelPackage::eINSTANCE.getSerComp(),YarelValidator::ERROR_SERIAL_COMPOSITION,"Arity of left and right branch must be equal")
+		model.assertError(YarelPackage::eINSTANCE.getDefinition(), YarelValidator::ERROR_OPERATIONS_TYPE, "Operations and input types are bad linked")
 	}
 	
+	/**
+	 * Added by Riccardo Viola
+	 */
 	@Test
-	def void testWrongDefinitionArity7()
-	{
-		var model = '''module m 
-		{ 
-			dcl f: int
-		    def f := for[inc];/1 2 3/ 
+	def void testOperationsLinking5(){
+		var model = '''module m {
+			dcl f : 2 bool, int -> 2 bool, int 
+			def f := tof
 		}'''.parse
-		model.assertError(YarelPackage::eINSTANCE.getSerComp(),YarelValidator::ERROR_SERIAL_COMPOSITION,"Arity of left and right branch must be equal")
+		model.assertError(YarelPackage::eINSTANCE.getDefinition(), YarelValidator::ERROR_OPERATIONS_TYPE, "Operations and input types are bad linked")
 	}
 	
+	/**
+	 * Added by Riccardo Viola.
+	 */
 	@Test
-	def void testWrongDefinitionArity8()
-	{
-		var model = '''module m 
-		{ 
-			dcl f: int, int
-		    def f := /1 2/;/1 2 3/ 
+	def void testOperationsLinking6(){
+		var model = '''module m {
+			dcl f : bool, int -> bool, int
+			def f := (inc | not)
 		}'''.parse
-		model.assertError(YarelPackage::eINSTANCE.getSerComp(),YarelValidator::ERROR_SERIAL_COMPOSITION,"Arity of left and right branch must be equal")
+		model.assertError(YarelPackage::eINSTANCE.getDefinition(), YarelValidator::ERROR_OPERATIONS_TYPE, "Operations and input types are bad linked")
 	}
 	
+	/**
+	 * Added by Riccardo Viola.
+	 */
 	@Test
-	def void testWrongDefinitionArity9()
-	{
-		var model = '''module m 
-		{ 
-			dcl f: 2 int
-			def f := /1 2/;/1 2 3/ 
+	def void testOperationsLinking7(){
+		var model = '''module m {
+			dcl f : 2 bool, int, bool -> 2 bool, int, bool 
+			def f := (tof | inc)
 		}'''.parse
-		model.assertError(YarelPackage::eINSTANCE.getSerComp(),YarelValidator::ERROR_SERIAL_COMPOSITION,"Arity of left and right branch must be equal")
+		model.assertError(YarelPackage::eINSTANCE.getDefinition(), YarelValidator::ERROR_OPERATIONS_TYPE, "Operations and input types are bad linked")
 	}
 	
+	/**
+	 * Added by Riccardo Viola.
+	 */
 	@Test
-	def void testWrongDefinitionArity10()
-	{
-		var model = '''module m 
-		{ 
-			dcl f: int, int
-		    def f := /1 2 3/;/1 2/ 
+	def void testOperationsLinking8(){
+		var model = '''module m {
+			dcl f : 2 int, 3 bool -> int, 3 bool, int
+			def f := (id | id | id | id | id);
+					 (tof | id | inc);
+					 /2 1 3 4 5/;
+					 (dec | id | id | id | id);
+					 /1 3 4 5 2/
 		}'''.parse
-		model.assertError(YarelPackage::eINSTANCE.getSerComp(),YarelValidator::ERROR_SERIAL_COMPOSITION,"Arity of left and right branch must be equal")
+		model.assertError(YarelPackage::eINSTANCE.getDefinition(), YarelValidator::ERROR_OPERATIONS_TYPE, "Operations and input types are bad linked")
 	}
 	
+	/**
+	 * Added by Riccardo Viola.
+	 */
 	@Test
-	def void testWrongDefinitionArity11()
-	{
-		var model = '''module m 
-		{ 
-			dcl f: int, int
-		    def f := /1 2 3/;/1 2/ 
+	def void testOperationsLinking9(){
+		var model = '''module m {
+			dcl f : 2 int, 3 bool -> int, 3 bool, int
+			def f := (id | id | id | id | id);
+					 (inc | id | tof);
+					 /2 1 3 4 5/;
+					 (tof | id | id);
+					 /1 3 4 5 2/
 		}'''.parse
-		model.assertError(YarelPackage::eINSTANCE.getSerComp(),YarelValidator::ERROR_SERIAL_COMPOSITION,"Arity of left and right branch must be equal")
+		model.assertError(YarelPackage::eINSTANCE.getDefinition(), YarelValidator::ERROR_OPERATIONS_TYPE, "Operations and input types are bad linked")
 	}
 	
+	/**
+	 * Added by Riccardo Viola.
+	 */
 	@Test
-	def void testWrongDefinitionArity12()
-	{
-		var model = '''module m 
-		{ 
-			dcl f: 2 int
-		    def f := /1 2 3/;/1 2/ 
+	def void testOperationsLinking10(){
+		var model = '''module m {
+			dcl f : 2 int, 3 bool -> int, 3 bool, int
+			def f := (id | id | id | id | id);
+					 (inc | id | tof);
+					 /2 1 3 4 5/;
+					 (dec | tof | id);
+					 /1 3 4 5 2/
 		}'''.parse
-		model.assertError(YarelPackage::eINSTANCE.getSerComp(),YarelValidator::ERROR_SERIAL_COMPOSITION,"Arity of left and right branch must be equal")
+		model.assertError(YarelPackage::eINSTANCE.getDefinition(), YarelValidator::ERROR_OPERATIONS_TYPE, "Operations and input types are bad linked")
 	}
 	
-	//Iteration
-	
+	/**
+	 * Added by Riccardo Viola.
+	 */
 	@Test
-	def void testWrongDefinitionArity13()
-	{
-		var model = '''module m 
-		{ 
-			dcl f: int
-		    def f := it[f];f 
+	def void testPermutationOrder1(){
+		var model = '''module m {
+			dcl f : bool, int -> bool, int
+			def f := /2 1/
 		}'''.parse
-		model.assertError(YarelPackage::eINSTANCE.getDefinition(),YarelValidator::ERROR_ARITY,"Different arities")
+		model.assertError(YarelPackage::eINSTANCE.getDefinition(), YarelValidator::ERROR_ORDER, "Different order between input and output types after operations")
 	}
 	
+	/**
+	 * Added by Riccardo Viola.
+	 */
 	@Test
-	def void testWrongDefinitionArity14()
-	{
-		var model = '''module m 
-		{ 
-			dcl f: int
-		    def f := f;it[f] 
+	def void testPermutationOrder2(){
+		var model = '''module m {
+			dcl f : int, bool -> int, bool
+			def f := /2 1/
 		}'''.parse
-		model.assertError(YarelPackage::eINSTANCE.getSerComp(),YarelValidator::ERROR_SERIAL_COMPOSITION,"Arity of left and right branch must be equal")
+		model.assertError(YarelPackage::eINSTANCE.getDefinition(), YarelValidator::ERROR_ORDER, "Different order between input and output types after operations")
 	}
 	
+	/**
+	 * Added by Riccardo Viola.
+	 */
 	@Test
-	def void testWrongDefinitionArity15()
-	{
-		var model = '''module m 
-		{ 
-			dcl f: 2 int
-		    def f := f;it[f] 
+	def void testPermutationOrder3(){
+		var model = '''module m {
+			dcl f : int, bool -> bool, int
+			def f := /2 1/;
+					 /2 1/
 		}'''.parse
-		model.assertError(YarelPackage::eINSTANCE.getSerComp(),YarelValidator::ERROR_SERIAL_COMPOSITION,"Arity of left and right branch must be equal")
+		model.assertError(YarelPackage::eINSTANCE.getDefinition(), YarelValidator::ERROR_ORDER, "Different order between input and output types after operations")
 	}
 	
+	/**
+	 * Added by Riccardo Viola.
+	 */
 	@Test
-	def void testWrongDefinitionArity16()
-	{
-		var model = '''module m 
-		{ 
-			dcl f: int, int
-		    def f := f;it[f] 
+	def void testPermutationOrder4(){
+		var model = '''module m {
+			dcl f : int, bool -> int, bool
+			def f := /2 1/;
+					 /2 1/;
+					 /2 1/
 		}'''.parse
-		model.assertError(YarelPackage::eINSTANCE.getSerComp(),YarelValidator::ERROR_SERIAL_COMPOSITION,"Arity of left and right branch must be equal")
+		model.assertError(YarelPackage::eINSTANCE.getDefinition(), YarelValidator::ERROR_ORDER, "Different order between input and output types after operations")
 	}
 	
+	/**
+	 * Added by Riccardo Viola.
+	 */
 	@Test
-	def void testWrongDefinitionArity17()
-	{
-		var model = '''module m 
-		{ 
-			dcl f: int
-		    def f := /1/;it[inc] 
+	def void testPermutationOrder5(){
+		var model = '''module m {
+			dcl f : 2 int, 3 bool -> int, 3 bool, int
+			def f := (id | id | id | id | id);
+					 (inc | id | tof);
+					 /2 1 3 4 5/;
+					 (dec | id | id | id | id);
+					 /1 3 4 2 5/
 		}'''.parse
-		model.assertError(YarelPackage::eINSTANCE.getSerComp(),YarelValidator::ERROR_SERIAL_COMPOSITION,"Arity of left and right branch must be equal")
+		model.assertError(YarelPackage::eINSTANCE.getDefinition(), YarelValidator::ERROR_ORDER, "Different order between input and output types after operations")
 	}
 	
+	/**
+	 * Added by Riccardo Viola.
+	 */
 	@Test
-	def void testWrongDefinitionArity18()
-	{
-		var model = '''module m 
-		{ 
-			dcl f: int
-		    def f := it[inc];/1/ 
+	def void testPermutationOrder6(){
+		var model = '''module m {
+			dcl f : 2 int, 3 bool -> int, 3 bool, int
+			def f := (id | id | id | id | id);
+					 (inc | id | tof);
+					 /2 3 1 4 5/;
+					 (dec | id | id | id | id);
+					 /1 3 4 5 2/
 		}'''.parse
-		model.assertError(YarelPackage::eINSTANCE.getSerComp(),YarelValidator::ERROR_SERIAL_COMPOSITION,"Arity of left and right branch must be equal")
+		model.assertError(YarelPackage::eINSTANCE.getDefinition(), YarelValidator::ERROR_ORDER, "Different order between input and output types after operations")
 	}
 	
+	/**
+	 * Added by Riccardo Viola.
+	 */
 	@Test
-	def void testWrongDefinitionArity19()
-	{
-		var model = '''module m 
-		{ 
-			dcl f: int
-		    def f := /1 2 3/;it[inc] 
+	def void testPermutationOrder7(){
+		var model = '''module m {
+			dcl f : int, bool, int, bool -> int, bool, int, bool
+			def f := /2 4 3 1/;
+				     /4 1 3 2/;
+					 /2 4 3 1/;
+					 inv[/2 3 1 4/]
 		}'''.parse
-		model.assertError(YarelPackage::eINSTANCE.getSerComp(),YarelValidator::ERROR_SERIAL_COMPOSITION,"Arity of left and right branch must be equal")
+		model.assertError(YarelPackage::eINSTANCE.getDefinition(), YarelValidator::ERROR_ORDER, "Different order between input and output types after operations")
 	}
 	
-	@Test
-	def void testWrongDefinitionArity20()
-	{
-		var model = '''module m 
-		{ 
-			dcl f: int
-		    def f := it[inc];/1 2 3/ 
-		}'''.parse
-		model.assertError(YarelPackage::eINSTANCE.getSerComp(),YarelValidator::ERROR_SERIAL_COMPOSITION,"Arity of left and right branch must be equal")
-	}
-	
-	@Test
-	def void testWrongDefinitionArity21()
-	{
-		var model = '''module m 
-		{ 
-			dcl f: int, int
-		    def f := /1 2/;/1 2 3/ 
-		}'''.parse
-		model.assertError(YarelPackage::eINSTANCE.getSerComp(),YarelValidator::ERROR_SERIAL_COMPOSITION,"Arity of left and right branch must be equal")
-	}
-	
-	@Test
-	def void testWrongDefinitionArity22()
-	{
-		var model = '''module m 
-		{ 
-			dcl f: 2 int
-			def f := /1 2/;/1 2 3/ 
-		}'''.parse
-		model.assertError(YarelPackage::eINSTANCE.getSerComp(),YarelValidator::ERROR_SERIAL_COMPOSITION,"Arity of left and right branch must be equal")
-	}
-	
-	@Test
-	def void testWrongDefinitionArity23()
-	{
-		var model = '''module m 
-		{ 
-			dcl f: int, int
-		    def f := /1 2 3/;/1 2/ 
-		}'''.parse
-		model.assertError(YarelPackage::eINSTANCE.getSerComp(),YarelValidator::ERROR_SERIAL_COMPOSITION,"Arity of left and right branch must be equal")
-	}
-	
-	@Test
-	def void testWrongDefinitionArity24()
-	{
-		var model = '''module m 
-		{ 
-			dcl f: int, int
-		    def f := /1 2 3/;/1 2/ 
-		}'''.parse
-		model.assertError(YarelPackage::eINSTANCE.getSerComp(),YarelValidator::ERROR_SERIAL_COMPOSITION,"Arity of left and right branch must be equal")
-	}
-	
-	@Test
-	def void testWrongDefinitionArity25()
-	{
-		var model = '''module m 
-		{ 
-			dcl f: 2 int
-		    def f := /1 2 3/;/1 2/ 
-		}'''.parse
-		model.assertError(YarelPackage::eINSTANCE.getSerComp(),YarelValidator::ERROR_SERIAL_COMPOSITION,"Arity of left and right branch must be equal")
-	}
 }


### PR DESCRIPTION
Necessarily the old generator tests, involving integer types only, have been upgraded to new type syntax.
New tests have been devised for tof and not functions.

Fixes #33 

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update relative to validation tests only
